### PR TITLE
Move to related

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -213,6 +213,9 @@ export default defineMessages(messages);
 ### [babel-plugin-react-intl-id-hash](https://github.com/adam-26/babel-plugin-react-intl-id-hash)
 If you want short consistent hash values for the ID, you can use [react-intl-id-hash](https://github.com/adam-26/babel-plugin-react-intl-id-hash) in addition to this plugin to help reduce your applications bundle size.
 
+ ### [extract-react-intl-messages](https://github.com/akameco/extract-react-intl-messages)
+Extract react-intl messages.
+
 ## Contributors
 
 Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds/all-contributors#emoji-key)):

--- a/readme.md
+++ b/readme.md
@@ -19,8 +19,6 @@ Based on the file path, this automatically generate a prefixed id.
 Also, we strongly encourage you to use [extract-react-intl-messages](https://github.com/akameco/extract-react-intl-messages).
 You can generate json automatically.
 
-If you want short consistent hash values for the ID, you can use [react-intl-id-hash](https://github.com/adam-26/babel-plugin-react-intl-id-hash) in addition to this plugin to help reduce your applications bundle size.
-
 Goodbye, global ID!!
 
 ### Before
@@ -166,7 +164,7 @@ if `filebase` is `true`, generate id with filename.
 Type: `boolean | 'all'` <br>
 Default: `false`
 
-if `includeExportName` is `true`, adds named exports as part of the id. 
+if `includeExportName` is `true`, adds named exports as part of the id.
 
 ##### Example
 
@@ -200,7 +198,7 @@ export default defineMessages(messages)
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-const messages = { 
+const messages = {
   hello: {
     id: 'src.components.App.hello',
     defaultMessage: 'hello wolrd'
@@ -210,6 +208,10 @@ const messages = {
 export default defineMessages(messages);
 ```
 
+## Related
+
+### [babel-plugin-react-intl-id-hash](https://github.com/adam-26/babel-plugin-react-intl-id-hash)
+If you want short consistent hash values for the ID, you can use [react-intl-id-hash](https://github.com/adam-26/babel-plugin-react-intl-id-hash) in addition to this plugin to help reduce your applications bundle size.
 
 ## Contributors
 


### PR DESCRIPTION
hash化はいいアイデアです。
が、多くの場合、これをオススメしたくはありません。
なぜなら、キーの管理が複雑になるからです。
また、ファイルサイズの削減のためにコンポーネントベースのプレフィックスを付けています。
jsonはCode Splittingにより分割し、それぞれのコンポーネントで遅延ロードできるからです。

しかし、今のreadmeだとhash化を推奨しているように見えます。
それは本意ではありません。
`related `セクションに移動させます。

--- 

`I used Google Translate. I'm sorry if the grammar is weird.`

hash is a good idea.
But in many cases, I do not want to recommend this.
Because key management becomes complicated.
In addition, a component-based prefix is added to reduce file size.
Because json can be divided by Code Splitting and lazily loaded by each component.

However, it seems to be recommended to have hash as it is now readme.
That is not true.
Move to `related` section.

cc @adam-26 