### PR TITLE
Add option to use leading comments as description

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -186,6 +186,31 @@ export const test = defineMessages({
 If includeExportName is `'all'`, it will also add `default` to the id on default
 exports.
 
+#### extractComments
+
+Use leading comments as the message description
+
+Type: `boolean` <br>
+Default: `false`
+
+##### Example
+
+```js
+export const test = defineMessages({
+  // Message used to greet the user
+  hello: 'hello {name}',
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+export const test = defineMessages({
+  hello: {
+    id: 'path.to.file.test.hello',
+    defaultMessage: 'hello {name}',
+    description: 'Message used to greet the user',
+  },
+})
+```
 
 ### Support variable
 

--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -118,14 +118,16 @@ export default defineMessages({
   // The main Hello of our app.
   hello: {
     'id': 'src.__fixtures__.hello',
-    'defaultMessage': 'hello'
+    'defaultMessage': 'hello',
+    'description': 'The main Hello of our app.'
   },
 
   // Another Hello,
   // multiline this time
   world: {
     id: 'hello.world',
-    defaultMessage: 'hello world'
+    defaultMessage: 'hello world',
+    'description': 'Another Hello,\\\\nmultiline this time'
   }
 });
 "
@@ -354,7 +356,7 @@ hello({
 "
 `;
 
-exports[`extractComments = true - default 1`] = `
+exports[`extractComments = false - default 1`] = `
 "
 import { defineMessages } from 'react-intl'
 
@@ -380,7 +382,7 @@ export default defineMessages({
 "
 `;
 
-exports[`extractComments = true - leading comment 1`] = `
+exports[`extractComments = false - leading comment 1`] = `
 "
 import { defineMessages } from 'react-intl'
 
@@ -404,22 +406,20 @@ export default defineMessages({
   // The main Hello of our app.
   hello: {
     'id': 'src.__fixtures__.hello',
-    'defaultMessage': 'hello',
-    'description': 'The main Hello of our app.'
+    'defaultMessage': 'hello'
   },
 
   // Another Hello,
   // multiline this time
   world: {
     id: 'hello.world',
-    defaultMessage: 'hello world',
-    'description': 'Another Hello,\\\\nmultiline this time'
+    defaultMessage: 'hello world'
   }
 });
 "
 `;
 
-exports[`extractComments = true - leading comment with description 1`] = `
+exports[`extractComments = false - leading comment with description 1`] = `
 "
 import { defineMessages } from 'react-intl'
 

--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -94,6 +94,73 @@ m({
 "
 `;
 
+exports[`default - leading comment 1`] = `
+"
+import { defineMessages } from 'react-intl'
+
+export default defineMessages({
+  // The main Hello of our app.
+  hello: 'hello',
+
+  // Another Hello,
+  // multiline this time
+  world: {
+    id: 'hello.world',
+    defaultMessage: 'hello world',
+  }
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { defineMessages } from 'react-intl';
+
+export default defineMessages({
+  // The main Hello of our app.
+  hello: {
+    'id': 'src.__fixtures__.hello',
+    'defaultMessage': 'hello'
+  },
+
+  // Another Hello,
+  // multiline this time
+  world: {
+    id: 'hello.world',
+    defaultMessage: 'hello world'
+  }
+});
+"
+`;
+
+exports[`default - leading comment with description 1`] = `
+"
+import { defineMessages } from 'react-intl'
+
+export default defineMessages({
+
+  // This comment should not be used
+  world: {
+    defaultMessage: 'hello world',
+    description: 'The hello world',
+  }
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { defineMessages } from 'react-intl';
+
+export default defineMessages({
+
+  // This comment should not be used
+  world: {
+    'id': 'src.__fixtures__.world',
+
+    defaultMessage: 'hello world',
+    description: 'The hello world'
+  }
+});
+"
+`;
+
 exports[`default - multi export 1`] = `
 "
 import { defineMessages } from 'react-intl'
@@ -283,6 +350,101 @@ defineMessages({
 
 hello({
   id: 'hoge'
+});
+"
+`;
+
+exports[`extractComments = true - default 1`] = `
+"
+import { defineMessages } from 'react-intl'
+
+export default defineMessages({
+  hello: 'hello',
+  world: 'hello world',
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { defineMessages } from 'react-intl';
+
+export default defineMessages({
+  hello: {
+    'id': 'src.__fixtures__.hello',
+    'defaultMessage': 'hello'
+  },
+  world: {
+    'id': 'src.__fixtures__.world',
+    'defaultMessage': 'hello world'
+  }
+});
+"
+`;
+
+exports[`extractComments = true - leading comment 1`] = `
+"
+import { defineMessages } from 'react-intl'
+
+export default defineMessages({
+  // The main Hello of our app.
+  hello: 'hello',
+
+  // Another Hello,
+  // multiline this time
+  world: {
+    id: 'hello.world',
+    defaultMessage: 'hello world',
+  }
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { defineMessages } from 'react-intl';
+
+export default defineMessages({
+  // The main Hello of our app.
+  hello: {
+    'id': 'src.__fixtures__.hello',
+    'defaultMessage': 'hello',
+    'description': 'The main Hello of our app.'
+  },
+
+  // Another Hello,
+  // multiline this time
+  world: {
+    id: 'hello.world',
+    defaultMessage: 'hello world',
+    'description': 'Another Hello,\\\\nmultiline this time'
+  }
+});
+"
+`;
+
+exports[`extractComments = true - leading comment with description 1`] = `
+"
+import { defineMessages } from 'react-intl'
+
+export default defineMessages({
+
+  // This comment should not be used
+  world: {
+    defaultMessage: 'hello world',
+    description: 'The hello world',
+  }
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { defineMessages } from 'react-intl';
+
+export default defineMessages({
+
+  // This comment should not be used
+  world: {
+    'id': 'src.__fixtures__.world',
+
+    defaultMessage: 'hello world',
+    description: 'The hello world'
+  }
 });
 "
 `;

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -268,7 +268,7 @@ pTest({
 })
 
 pTest({
-  title: 'extractComments = true',
+  title: 'extractComments = false',
   tests: [defaultTest, leadingCommentTest, leadingCommentWithDescriptionTest],
-  pluginOptions: { extractComments: true },
+  pluginOptions: { extractComments: false },
 })

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -40,6 +40,41 @@ export default defineMessages({
 `,
 }
 
+const leadingCommentTest = {
+  title: 'leading comment',
+  code: `
+import { defineMessages } from 'react-intl'
+
+export default defineMessages({
+  // The main Hello of our app.
+  hello: 'hello',
+
+  // Another Hello,
+  // multiline this time
+  world: {
+    id: 'hello.world',
+    defaultMessage: 'hello world',
+  }
+})
+`,
+}
+
+const leadingCommentWithDescriptionTest = {
+  title: 'leading comment with description',
+  code: `
+import { defineMessages } from 'react-intl'
+
+export default defineMessages({
+
+  // This comment should not be used
+  world: {
+    defaultMessage: 'hello world',
+    description: 'The hello world',
+  }
+})
+`,
+}
+
 const tests = [
   defaultTest,
   {
@@ -159,6 +194,8 @@ import { defineMessages } from 'react-intl'
 export default defineMessages(messages)
     `,
   },
+  leadingCommentTest,
+  leadingCommentWithDescriptionTest,
 ]
 
 type PTestOpts = {
@@ -228,4 +265,10 @@ pTest({
   title: 'removePrefix = true, includeExportName = all',
   tests: [defaultTest, multiExportTest],
   pluginOptions: { removePrefix: true, includeExportName: 'all' },
+})
+
+pTest({
+  title: 'extractComments = true',
+  tests: [defaultTest, leadingCommentTest, leadingCommentWithDescriptionTest],
+  pluginOptions: { extractComments: true },
 })

--- a/src/index.js
+++ b/src/index.js
@@ -85,9 +85,16 @@ const isValidate = (path: Object, state: State): boolean => {
   return true
 }
 
+const getLeadingComment = prop => {
+  const commentNodes = prop.node.leadingComments
+  return commentNodes
+    ? commentNodes.map(node => node.value.trim()).join('\n')
+    : null
+}
+
 const replaceProperties = (
   properties: $ReadOnlyArray<Object>,
-  state,
+  state: State,
   exportName: string | null
 ) => {
   const prefix = getPrefix(state, exportName)
@@ -95,35 +102,55 @@ const replaceProperties = (
   for (const prop of properties) {
     const propValue = prop.get('value')
 
+    const messageDescriptorProperties = []
+
     // { defaultMessage: 'hello', description: 'this is hello' }
     if (propValue.isObjectExpression()) {
       const objProps = propValue.get('properties')
 
       // { id: 'already has id', defaultMessage: 'hello' }
       const isNotHaveId = objProps.every(v => v.get('key').node.name !== 'id')
-      if (!isNotHaveId) {
-        continue // eslint-disable-line
+      if (isNotHaveId) {
+        const id = getId(prop.get('key'), prefix)
+
+        messageDescriptorProperties.push(
+          t.objectProperty(t.stringLiteral('id'), t.stringLiteral(id))
+        )
       }
 
-      const id = getId(prop.get('key'), prefix)
-
-      propValue.replaceWith(
-        t.objectExpression([
-          t.objectProperty(t.stringLiteral('id'), t.stringLiteral(id)),
-          ...objProps.map(v => v.node),
-        ])
-      )
+      messageDescriptorProperties.push(...objProps.map(v => v.node))
 
       // 'hello' or `hello ${user}`
     } else if (isLiteral(propValue)) {
       const id = getId(prop.get('key'), prefix)
 
-      propValue.replaceWith(
-        t.objectExpression([
-          t.objectProperty(t.stringLiteral('id'), t.stringLiteral(id)),
-          t.objectProperty(t.stringLiteral('defaultMessage'), propValue.node),
-        ])
+      messageDescriptorProperties.push(
+        t.objectProperty(t.stringLiteral('id'), t.stringLiteral(id)),
+        t.objectProperty(t.stringLiteral('defaultMessage'), propValue.node)
       )
+    }
+
+    if (state.opts.extractComments) {
+      const hasDescription = messageDescriptorProperties.find((v: Object) => {
+        return v.key.name === 'description'
+      })
+
+      if (!hasDescription) {
+        const description = getLeadingComment(prop)
+
+        if (description) {
+          messageDescriptorProperties.push(
+            t.objectProperty(
+              t.stringLiteral('description'),
+              t.stringLiteral(description)
+            )
+          )
+        }
+      }
+    }
+
+    if (messageDescriptorProperties.length > 0) {
+      propValue.replaceWith(t.objectExpression(messageDescriptorProperties))
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -130,7 +130,12 @@ const replaceProperties = (
       )
     }
 
-    if (state.opts.extractComments) {
+    const extractComments =
+      state.opts.extractComments === undefined
+        ? true
+        : state.opts.extractComments
+
+    if (extractComments) {
       const hasDescription = messageDescriptorProperties.find((v: Object) => {
         return v.key.name === 'description'
       })
@@ -149,9 +154,7 @@ const replaceProperties = (
       }
     }
 
-    if (messageDescriptorProperties.length > 0) {
-      propValue.replaceWith(t.objectExpression(messageDescriptorProperties))
-    }
+    propValue.replaceWith(t.objectExpression(messageDescriptorProperties))
   }
 }
 

--- a/src/types.js
+++ b/src/types.js
@@ -18,5 +18,6 @@ export type State = {
     removePrefix?: string,
     filebase?: boolean,
     includeExportName?: boolean | 'all',
+    extractComments?: boolean,
   },
 }


### PR DESCRIPTION
This PR implements issue #18 by adding a new configuration option `extractComments`.

When its value is `true`, any leading comment will be used as the value for the `description` property of the message.