### PR TITLE
changed react-intl import matching algorighm to allow import paths (n…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const isImportLocalName = (
     ImportDeclaration: {
       exit(path) {
         isImported =
-          path.node.source.value === 'react-intl' &&
+          path.node.source.value.indexOf('react-intl') > -1 &&
           path.get('specifiers').some(isSearchedImportSpecifier)
 
         if (isImported) {


### PR DESCRIPTION
…eeded with yarn workspaces)

**What**:
Changed import checking algorithm to be able to have react-intl as substring of import.

**Why**:
Otherwise it's not working with yarn workspaces which makes import paths relative.

**Checklist**: 
* [ ] Documentation
* [ ] Tests
* [x] Ready to be merged
* [ ] Added myself to contributors table