### PR TITLE
feat: support removePrefix=regex

### DIFF
--- a/src/__tests__/__snapshots__/components.test.js.snap
+++ b/src/__tests__/__snapshots__/components.test.js.snap
@@ -194,6 +194,20 @@ import { FormattedMessage } from 'react-intl';
 "
 `;
 
+exports[`removePrefix = /__fixtures__/ default: default 1`] = `
+"
+import { FormattedMessage } from 'react-intl';
+
+<FormattedMessage defaultMessage=\\"hello\\" />;
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { FormattedMessage } from 'react-intl';
+
+<FormattedMessage id=\\"src.613153351\\" defaultMessage=\\"hello\\" />;
+"
+`;
+
 exports[`removePrefix = false default: default 1`] = `
 "
 import { FormattedMessage } from 'react-intl';

--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -658,6 +658,27 @@ export default defineMessages({
 "
 `;
 
+exports[`removePrefix = /__fixtures__/ default: default 1`] = `
+"
+import { defineMessages } from 'react-intl'
+
+export default defineMessages({
+  hello: 'hello',
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { defineMessages } from 'react-intl';
+
+export default defineMessages({
+  hello: {
+    'id': '_.hello',
+    'defaultMessage': 'hello'
+  }
+});
+"
+`;
+
 exports[`removePrefix = false default: default 1`] = `
 "
 import { defineMessages } from 'react-intl'

--- a/src/__tests__/components.test.js
+++ b/src/__tests__/components.test.js
@@ -169,6 +169,11 @@ cases([
     tests: [defaultTest],
     pluginOptions: { extractComments: false },
   },
+  {
+    title: 'removePrefix = /__fixtures__/',
+    tests: [defaultTest],
+    pluginOptions: { removePrefix: /\/__fixtures__/ },
+  },
 ])
 
 function cases(

--- a/src/__tests__/components.test.js
+++ b/src/__tests__/components.test.js
@@ -171,6 +171,7 @@ cases([
   },
   {
     title: 'removePrefix = /__fixtures__/',
+    skip: process.platform === 'win32',
     tests: [defaultTest],
     pluginOptions: { removePrefix: /\/__fixtures__/ },
   },

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -274,6 +274,11 @@ cases([
     tests: [defaultTest, leadingCommentTest, leadingCommentWithDescriptionTest],
     pluginOptions: { extractComments: false },
   },
+  {
+    title: 'removePrefix = /__fixtures__/',
+    tests: [defaultTest],
+    pluginOptions: { removePrefix: /src\/__f.+?_/, includeExportName: true },
+  },
 ])
 
 function cases(

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -276,6 +276,7 @@ cases([
   },
   {
     title: 'removePrefix = /__fixtures__/',
+    skip: process.platform === 'win32',
     tests: [defaultTest],
     pluginOptions: { removePrefix: /src\/__f.+?_/, includeExportName: true },
   },

--- a/src/index.js
+++ b/src/index.js
@@ -53,10 +53,13 @@ const getPrefix = (
   const file = p.relative(process.cwd(), filename)
   const fomatted = filebase ? file.replace(/\..+$/, '') : p.dirname(file)
   removePrefix = removePrefix === false ? '' : removePrefix
-  const fixed = dotPath(fomatted).replace(
-    new RegExp(`^${removePrefix.replace(/\//g, '')}\\${dotPath(p.sep)}?`),
-    ''
-  )
+  const fixed =
+    removePrefix instanceof RegExp
+      ? dotPath(fomatted.replace(removePrefix, ''))
+      : dotPath(fomatted).replace(
+          new RegExp(`^${removePrefix.replace(/\//g, '')}\\${dotPath(p.sep)}?`),
+          ''
+        )
   const result = exportName === null ? fixed : `${fixed}.${exportName}`
   return result
 }


### PR DESCRIPTION
**What**: removePrefixのオプションにregexをサポート

**Why**: see #45 

**How**: `instanceof RegExp` で判定。

**Checklist**: 
* [ ] Documentation
* [ ] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments. -->

resolve #45 

## Notice
When using regex, please use `.babelrc.js` instead of `.babelrc`.

`.babelrc` → `.babelrc.js` 

Only mac and linux correspond.


