### PR TITLE
Allow to provide custom module name/path from where imports will be resolved

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -156,6 +156,15 @@
         "code",
         "test"
       ]
+    },
+    {
+      "login": "Filson14",
+      "name": "Filip \"Filson\" Pasternak",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/4540538?v=4",
+      "profile": "https://github.com/Filson14",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "repoType": "github",

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/akameco/babel-plugin-react-intl-auto/badge.svg?branch=master)](https://coveralls.io/github/akameco/babel-plugin-react-intl-auto?branch=master)
 [![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 [![tested with jest](https://img.shields.io/badge/tested_with-jest-99424f.svg)](https://github.com/facebook/jest)
-[![All Contributors](https://img.shields.io/badge/all_contributors-15-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-16-orange.svg?style=flat-square)](#contributors-)
 [![babel-plugin-react-intl-auto Dev Token](https://badge.devtoken.rocks/babel-plugin-react-intl-auto)](https://devtoken.rocks/package/babel-plugin-react-intl-auto)
 
 > i18n for the component age. Auto management react-intl ID.
@@ -456,6 +456,7 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
   </tr>
   <tr>
     <td align="center"><a href="https://github.com/dominik-zeglen"><img src="https://avatars3.githubusercontent.com/u/6833443?v=4" width="100px;" alt="Dominik Żegleń"/><br /><sub><b>Dominik Żegleń</b></sub></a><br /><a href="https://github.com/akameco/babel-plugin-react-intl-auto/commits?author=dominik-zeglen" title="Code">💻</a> <a href="https://github.com/akameco/babel-plugin-react-intl-auto/commits?author=dominik-zeglen" title="Tests">⚠️</a></td>
+    <td align="center"><a href="https://github.com/Filson14"><img src="https://avatars1.githubusercontent.com/u/4540538?v=4" width="100px;" alt="Filip "Filson" Pasternak"/><br /><sub><b>Filip "Filson" Pasternak</b></sub></a><br /><a href="https://github.com/akameco/babel-plugin-react-intl-auto/commits?author=Filson14" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/readme.md
+++ b/readme.md
@@ -267,6 +267,13 @@ Default: `false`
 
 if `filebase` is `true`, generate id with filename.
 
+#### moduleSourceName
+
+Type: `string` <br>
+Default: `react-intl`
+
+if set, enables to use custom module as a source for _defineMessages_ etc.
+
 #### includeExportName
 
 Type: `boolean | 'all'` <br>

--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -579,6 +579,43 @@ export default defineMessages({
 
 `;
 
+exports[`moduleSourceNameTest default: default 1`] = `
+
+import { defineMessages } from 'react-intl'
+
+export default defineMessages({
+  hello: 'hello',
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { defineMessages } from 'react-intl';
+export default defineMessages({
+  hello: 'hello'
+});
+
+`;
+
+exports[`moduleSourceNameTest moduleSourceName: moduleSourceName 1`] = `
+
+import { defineMessages } from 'gatsby-plugin-intl'
+
+export default defineMessages({
+  hello: 'hello',
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { defineMessages } from 'gatsby-plugin-intl';
+export default defineMessages({
+  hello: {
+    "id": "src.__fixtures__.hello",
+    "defaultMessage": 'hello'
+  }
+});
+
+`;
+
 exports[`removePrefix = "src" default: default 1`] = `
 
 import { defineMessages } from 'react-intl'

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -227,6 +227,17 @@ export default defineMessages({
   },
 ]
 
+const moduleSourceNameTest = {
+  title: 'moduleSourceName',
+  code: `
+import { defineMessages } from 'gatsby-plugin-intl'
+
+export default defineMessages({
+  hello: 'hello',
+})
+  `,
+}
+
 cases([
   { title: 'default', tests },
   {
@@ -297,6 +308,13 @@ cases([
       includeExportName: true,
     },
   },
+  {
+    title: 'moduleSourceNameTest',
+    tests: [defaultTest, moduleSourceNameTest],
+    pluginOptions: {
+      moduleSourceName: 'gatsby-plugin-intl',
+    },
+  },
 ])
 
 function cases(
@@ -312,6 +330,7 @@ function cases(
     babelOptions: { filename },
     tests: [],
   }
+  // eslint-disable-next-line no-unused-vars
   for (const testCase of testCases) {
     testCase.tests = testCase.tests.map(t => ({ ...t, title: t.title }))
     pluginTester({ ...defaultOpts, ...testCase })

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import type { State } from './types'
 const isImportLocalName = (
   name: ?string,
   allowedNames: $ReadOnlyArray<string>,
-  { file }: State
+  { file, opts: { moduleSourceName = 'react-intl' } }: State
 ) => {
   const isSearchedImportSpecifier = specifier =>
     specifier.isImportSpecifier() &&
@@ -21,7 +21,7 @@ const isImportLocalName = (
     ImportDeclaration: {
       exit(path) {
         isImported =
-          path.node.source.value.includes('react-intl') &&
+          path.node.source.value.includes(moduleSourceName) &&
           path.get('specifiers').some(isSearchedImportSpecifier)
 
         if (isImported) {

--- a/src/types.js
+++ b/src/types.js
@@ -21,5 +21,6 @@ export type State = {
     includeExportName?: boolean | 'all',
     extractComments?: boolean,
     useKey?: boolean,
+    moduleSourceName?: string,
   },
 }


### PR DESCRIPTION
I've added new option to the plugin to enable usage of custom module path/name like described here https://github.com/akameco/extract-react-intl/issues/18

Funny thing is that the plugin itself worked OK without that parameter even with custom module, but in conjuction with **extract-react-intl-messages**, errors are thrown and whole process fails.

**Checklist**: <!-- add "N/A" to the end of each line that's irrelevant to your changes to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [ ] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments. -->
