### PR TITLE
Add support for useKey option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -259,6 +259,24 @@ export const test = defineMessages({
 })
 ```
 
+#### useKey
+
+Only works with `FormattedMessage` and `FormattedHTMLMessage`. Instead of
+generating an ID by hashing `defaultMessage`, it will use the `key` property if
+it exists.
+
+Type: `boolean` <br>
+Default: `false`
+##### Example
+
+```js
+<FormattedMessage key="foobar" defaultMessage="hello" />
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+<FormattedMessage id="path.to.file.foobar" key="foobar" defaultMessage="hello" />
+```
+
 ### Support variable
 
 ##### Example

--- a/src/__tests__/__snapshots__/components.test.js.snap
+++ b/src/__tests__/__snapshots__/components.test.js.snap
@@ -43,6 +43,19 @@ import { FormattedMessage } from 'react-intl';
 
 `;
 
+exports[`default using key: using key 1`] = `
+
+import { FormattedMessage } from 'react-intl';
+
+<FormattedMessage key="foobar" defaultMessage="hello" />;
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { FormattedMessage } from 'react-intl';
+<FormattedMessage key="foobar" id="src.__fixtures__.613153351" defaultMessage="hello" />;
+
+`;
+
 exports[`default with FormattedMessage imported as something else: with FormattedMessage imported as something else 1`] = `
 
 import { FormattedMessage as T } from 'react-intl';
@@ -242,5 +255,31 @@ import { FormattedMessage } from 'react-intl';
 
 import { FormattedMessage } from 'react-intl';
 <FormattedMessage id="613153351" defaultMessage="hello" />;
+
+`;
+
+exports[`useKey = true default: default 1`] = `
+
+import { FormattedMessage } from 'react-intl';
+
+<FormattedMessage defaultMessage="hello" />;
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { FormattedMessage } from 'react-intl';
+<FormattedMessage id="src.__fixtures__.613153351" defaultMessage="hello" />;
+
+`;
+
+exports[`useKey = true using key: using key 1`] = `
+
+import { FormattedMessage } from 'react-intl';
+
+<FormattedMessage key="foobar" defaultMessage="hello" />;
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { FormattedMessage } from 'react-intl';
+<FormattedMessage key="foobar" id="src.__fixtures__.foobar" defaultMessage="hello" />;
 
 `;

--- a/src/__tests__/components.test.js
+++ b/src/__tests__/components.test.js
@@ -108,6 +108,15 @@ const props = {
 `,
 }
 
+const keyTest = {
+  title: 'using key',
+  code: `
+import { FormattedMessage } from 'react-intl';
+
+<FormattedMessage key="foobar" defaultMessage="hello" />;
+`,
+}
+
 const tests = [
   defaultTest,
   multiUseTest,
@@ -119,10 +128,16 @@ const tests = [
   throwWhenNotAnalyzableTest,
   notTransformIfNotImportedTest,
   notTransformIfSpreadAttributeTest,
+  keyTest,
 ]
 
 cases([
   { title: 'default', tests },
+  {
+    title: 'useKey = true',
+    tests: [defaultTest, keyTest],
+    pluginOptions: { useKey: true },
+  },
   {
     title: 'removePrefix = "src"',
     tests: [defaultTest],

--- a/src/types.js
+++ b/src/types.js
@@ -20,5 +20,6 @@ export type State = {
     filebase?: boolean,
     includeExportName?: boolean | 'all',
     extractComments?: boolean,
+    useKey?: boolean,
   },
 }


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) / 何が変更されていますか？-->
**What**: Adds a new `useKey` option.


<!-- Why are these changes necessary? / なぜその変更をする必要がありましたか？-->
**Why**: When `useKey = true`, calling `FormattedMessage` or `FormattedHTMLMessage` with a `key` prop will attempt to use `key` as the ID suffix, instead of generating a hash with `defaultMessage`. This is helpful as `FormattedMessage` is much simpler than `defineMessages`, but you still want to benefit from full-path ID generation.

**Checklist**: <!-- add "N/A" to the end of each line that's irrelevant to your changes to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions --> N/A
