### PR TITLE
Feature intl.formatMessage() support

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -136,6 +136,16 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "jmarceli",
+      "name": "jmarceli",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/4281333?v=4",
+      "profile": "https://github.com/jmarceli",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ],
   "repoType": "github",

--- a/readme.md
+++ b/readme.md
@@ -120,6 +120,46 @@ $ yarn add --dev @babel/plugin-transform-typescript
 }
 ```
 
+## Example
+
+### with injectIntl
+
+Input:
+
+```js
+import { injectIntl } from 'react-intl'
+
+const MyComponent = (({ intl }) => {
+  const label = intl.formatMessage({ defaultMessage: 'Submit button' })
+  return (
+    <button aria-label={label}>
+      {label}
+    </button>
+  )
+))
+
+injectIntl(MyComponent)
+```
+
+↓ 　 ↓ 　 ↓
+
+Output:
+
+```js
+import { injectIntl } from 'react-intl'
+
+const MyComponent = ({ intl }) => {
+  const label = intl.formatMessage({ id="App.Components.Button.label", defaultMessage: 'Submit button' })
+  return (
+    <button aria-label={label}>
+      {label}
+    </button>
+  )
+}
+
+injectIntl(MyComponent)
+```
+
 ### Options
 
 #### removePrefix

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/akameco/babel-plugin-react-intl-auto/badge.svg?branch=master)](https://coveralls.io/github/akameco/babel-plugin-react-intl-auto?branch=master)
 [![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 [![tested with jest](https://img.shields.io/badge/tested_with-jest-99424f.svg)](https://github.com/facebook/jest)
-[![All Contributors](https://img.shields.io/badge/all_contributors-13-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-14-orange.svg?style=flat-square)](#contributors-)
 [![babel-plugin-react-intl-auto Dev Token](https://badge.devtoken.rocks/babel-plugin-react-intl-auto)](https://devtoken.rocks/package/babel-plugin-react-intl-auto)
 
 > i18n for the component age. Auto management react-intl ID.
@@ -381,6 +381,7 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
     <td align="center"><a href="https://github.com/kuma-kuma"><img src="https://avatars0.githubusercontent.com/u/12218082?v=4" width="100px;" alt="Kouta Kumagai"/><br /><sub><b>Kouta Kumagai</b></sub></a><br /><a href="https://github.com/akameco/babel-plugin-react-intl-auto/commits?author=kuma-kuma" title="Documentation">📖</a> <a href="https://github.com/akameco/babel-plugin-react-intl-auto/commits?author=kuma-kuma" title="Code">💻</a> <a href="https://github.com/akameco/babel-plugin-react-intl-auto/commits?author=kuma-kuma" title="Tests">⚠️</a></td>
     <td align="center"><a href="http://shah.yar.gs"><img src="https://avatars0.githubusercontent.com/u/255846?v=4" width="100px;" alt="Shahyar G"/><br /><sub><b>Shahyar G</b></sub></a><br /><a href="https://github.com/akameco/babel-plugin-react-intl-auto/commits?author=shahyar" title="Code">💻</a></td>
     <td align="center"><a href="https://gitlab.com/remcohaszing"><img src="https://avatars2.githubusercontent.com/u/779047?v=4" width="100px;" alt="Remco Haszing"/><br /><sub><b>Remco Haszing</b></sub></a><br /><a href="https://github.com/akameco/babel-plugin-react-intl-auto/commits?author=remcohaszing" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/jmarceli"><img src="https://avatars1.githubusercontent.com/u/4281333?v=4" width="100px;" alt="jmarceli"/><br /><sub><b>jmarceli</b></sub></a><br /><a href="https://github.com/akameco/babel-plugin-react-intl-auto/commits?author=jmarceli" title="Code">💻</a> <a href="https://github.com/akameco/babel-plugin-react-intl-auto/commits?author=jmarceli" title="Tests">⚠️</a></td>
   </tr>
 </table>
 

--- a/src/__tests__/__snapshots__/injection.test.js.snap
+++ b/src/__tests__/__snapshots__/injection.test.js.snap
@@ -1,0 +1,247 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`default multiple uses: multiple uses 1`] = `
+
+import { injectIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "hello" });
+intl.formatMessage({ defaultMessage: "hello" });
+intl.formatMessage({ defaultMessage: "some other message" });
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { injectIntl } from 'react-intl';
+intl.formatMessage({
+  defaultMessage: "hello",
+  "id": "src.__fixtures__.613153351"
+});
+intl.formatMessage({
+  defaultMessage: "hello",
+  "id": "src.__fixtures__.613153351"
+});
+intl.formatMessage({
+  defaultMessage: "some other message",
+  "id": "src.__fixtures__.831373691"
+});
+
+`;
+
+exports[`default some supported use cases: some supported use cases 1`] = `
+
+import { injectIntl } from 'react-intl';
+
+const Component2 = ({ intl }) => {
+  const label = intl.formatMessage({ defaultMessage: "hello" });
+  return (
+    <button aria-label={intl.formatMessage({ defaultMessage: "hello" })}>
+      {intl.formatMessage({ defaultMessage: "hello" })}
+    </button>
+  );
+};
+injectIntl(Components2);
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { injectIntl } from 'react-intl';
+
+const Component2 = ({
+  intl
+}) => {
+  const label = intl.formatMessage({
+    defaultMessage: "hello",
+    "id": "src.__fixtures__.613153351"
+  });
+  return <button aria-label={intl.formatMessage({
+    defaultMessage: "hello",
+    "id": "src.__fixtures__.613153351"
+  })}>
+      {intl.formatMessage({
+      defaultMessage: "hello",
+      "id": "src.__fixtures__.613153351"
+    })}
+    </button>;
+};
+
+injectIntl(Components2);
+
+`;
+
+exports[`default with FormattedMessage imported as something else: with FormattedMessage imported as something else 1`] = `
+
+import { injectIntl as i18n } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "i18n" });
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { injectIntl as i18n } from 'react-intl';
+intl.formatMessage({
+  defaultMessage: "i18n",
+  "id": "src.__fixtures__.94348014"
+});
+
+`;
+
+exports[`default with Injection API HOC imported: with Injection API HOC imported 1`] = `
+
+import { injectIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "hello" });
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { injectIntl } from 'react-intl';
+intl.formatMessage({
+  defaultMessage: "hello",
+  "id": "src.__fixtures__.613153351"
+});
+
+`;
+
+exports[`default with a value interpolated in the message: with a value interpolated in the message 1`] = `
+
+import { injectIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: \`template string 2\` });
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { injectIntl } from 'react-intl';
+intl.formatMessage({
+  defaultMessage: \`template string 2\`,
+  "id": "src.__fixtures__.1045198380"
+});
+
+`;
+
+exports[`default with a variable as the defaultMessage: with a variable as the defaultMessage 1`] = `
+
+import { injectIntl } from 'react-intl';
+
+const message = "variable message";
+
+intl.formatMessage({ defaultMessage: message });
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { injectIntl } from 'react-intl';
+const message = "variable message";
+intl.formatMessage({
+  defaultMessage: message,
+  "id": "src.__fixtures__.3082794952"
+});
+
+`;
+
+exports[`default with custom properties in formatMessage call: with custom properties in formatMessage call 1`] = `
+
+import { injectIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "custom prop", other: 123 });
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { injectIntl } from 'react-intl';
+intl.formatMessage({
+  defaultMessage: "custom prop",
+  "id": "src.__fixtures__.2983810267",
+  other: 123
+});
+
+`;
+
+exports[`filebase = true with Injection API HOC imported: with Injection API HOC imported 1`] = `
+
+import { injectIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "hello" });
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { injectIntl } from 'react-intl';
+intl.formatMessage({
+  defaultMessage: "hello",
+  "id": "src.__fixtures__.messages.613153351"
+});
+
+`;
+
+exports[`removePrefix = "src" with Injection API HOC imported: with Injection API HOC imported 1`] = `
+
+import { injectIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "hello" });
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { injectIntl } from 'react-intl';
+intl.formatMessage({
+  defaultMessage: "hello",
+  "id": "__fixtures__.613153351"
+});
+
+`;
+
+exports[`removePrefix = "src.__fixtures__" with Injection API HOC imported: with Injection API HOC imported 1`] = `
+
+import { injectIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "hello" });
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { injectIntl } from 'react-intl';
+intl.formatMessage({
+  defaultMessage: "hello",
+  "id": "613153351"
+});
+
+`;
+
+exports[`removePrefix = "src/" -- with slash with Injection API HOC imported: with Injection API HOC imported 1`] = `
+
+import { injectIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "hello" });
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { injectIntl } from 'react-intl';
+intl.formatMessage({
+  defaultMessage: "hello",
+  "id": "__fixtures__.613153351"
+});
+
+`;
+
+exports[`removePrefix = /__fixtures__/ with Injection API HOC imported: with Injection API HOC imported 1`] = `
+
+import { injectIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "hello" });
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { injectIntl } from 'react-intl';
+intl.formatMessage({
+  defaultMessage: "hello",
+  "id": "src.613153351"
+});
+
+`;
+
+exports[`removePrefix = false with Injection API HOC imported: with Injection API HOC imported 1`] = `
+
+import { injectIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "hello" });
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { injectIntl } from 'react-intl';
+intl.formatMessage({
+  defaultMessage: "hello",
+  "id": "src.__fixtures__.613153351"
+});
+
+`;

--- a/src/__tests__/injection.test.js
+++ b/src/__tests__/injection.test.js
@@ -1,0 +1,208 @@
+// @flow
+import path from 'path'
+import pluginTester from 'babel-plugin-tester'
+import plugin from '..'
+
+const filename = path.resolve(__dirname, '..', '__fixtures__', 'messages.js')
+
+const defaultTest = {
+  title: 'with Injection API HOC imported',
+  code: `
+import { injectIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "hello" });
+  `,
+}
+
+const multiUseTest = {
+  title: 'multiple uses',
+  code: `
+import { injectIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "hello" });
+intl.formatMessage({ defaultMessage: "hello" });
+intl.formatMessage({ defaultMessage: "some other message" });
+`,
+}
+
+const withValueInMessageTest = {
+  title: 'with a value interpolated in the message',
+  code: `
+import { injectIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: \`template string ${1 + 1}\` });
+`,
+}
+
+const withVariableMessageTest = {
+  title: 'with a variable as the defaultMessage',
+  code: `
+import { injectIntl } from 'react-intl';
+
+const message = "variable message";
+
+intl.formatMessage({ defaultMessage: message });
+`,
+}
+
+const withCustomProperties = {
+  title: 'with custom properties in formatMessage call',
+  code: `
+import { injectIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "custom prop", other: 123 });
+`,
+}
+
+const someSupportedUseCases = {
+  title: 'some supported use cases',
+  code: `
+import { injectIntl } from 'react-intl';
+
+const Component2 = ({ intl }) => {
+  const label = intl.formatMessage({ defaultMessage: "hello" });
+  return (
+    <button aria-label={intl.formatMessage({ defaultMessage: "hello" })}>
+      {intl.formatMessage({ defaultMessage: "hello" })}
+    </button>
+  );
+};
+injectIntl(Components2);
+  `,
+}
+
+const importAsTest = {
+  title: 'with FormattedMessage imported as something else',
+  code: `
+import { injectIntl as i18n } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "i18n" });
+`,
+}
+
+const throwWhenNotAnalyzableTest = {
+  title: 'throws if defaultMessage isn’t analyzable',
+  code: `
+import { injectIntl } from 'react-intl';
+const getMsg = () => 'hello';
+intl.formatMessage({
+  defaultMessage: getMsg(),
+});
+`,
+  error: /\[React Intl Auto\] defaultMessage must be statically evaluate-able for extraction/u,
+  snapshot: false,
+}
+
+const notTransformIfNotImportedTest = {
+  title: 'does nothing if react-intl is not imported',
+  snapshot: false,
+  code: `
+import any from 'any-module';
+intl.formatMessage({
+  defaultMessage: "hello"
+});
+`,
+}
+
+const notTransformIfIdIsProvided = {
+  title: 'does nothing if id is already provided',
+  snapshot: false,
+  code: `
+import { injectIntl } from 'react-intl';
+intl.formatMessage({
+  id: "my.custom.id",
+  defaultMessage: "hello"
+});
+`,
+}
+
+const tests = [
+  defaultTest,
+  multiUseTest,
+  withValueInMessageTest,
+  withVariableMessageTest,
+  withCustomProperties,
+  someSupportedUseCases,
+  importAsTest,
+  throwWhenNotAnalyzableTest,
+  notTransformIfNotImportedTest,
+  notTransformIfIdIsProvided,
+]
+
+cases([
+  { title: 'default', tests },
+  {
+    title: 'removePrefix = "src"',
+    tests: [defaultTest],
+    pluginOptions: { removePrefix: 'src' },
+  },
+  {
+    title: 'removePrefix = "src/" -- with slash',
+    tests: [defaultTest],
+    pluginOptions: { removePrefix: 'src/' },
+  },
+  {
+    title: 'filebase = true',
+    tests: [defaultTest],
+    pluginOptions: { filebase: true },
+  },
+  // {
+  //   title: 'includeExportName = true',
+  //   tests: [defaultTest],
+  //   pluginOptions: { includeExportName: true },
+  // },
+  // {
+  //   title: 'includeExportName = all',
+  //   tests: [defaultTest],
+  //   pluginOptions: { includeExportName: 'all' },
+  // },
+  // {
+  //   title: 'removePrefix = true, includeExportName = true',
+  //   tests: [defaultTest],
+  //   pluginOptions: { removePrefix: true, includeExportName: true },
+  // },
+  {
+    title: 'removePrefix = false',
+    tests: [defaultTest],
+    pluginOptions: { removePrefix: false },
+  },
+  // {
+  //   title: 'removePrefix = true, includeExportName = all',
+  //   tests: [defaultTest],
+  //   pluginOptions: { removePrefix: true, includeExportName: 'all' },
+  // },
+  // {
+  //   title: 'extractComments = false',
+  //   tests: [defaultTest],
+  //   pluginOptions: { extractComments: false },
+  // },
+  {
+    title: 'removePrefix = /__fixtures__/',
+    tests: [defaultTest],
+    pluginOptions: { removePrefix: /[\\/]__fixtures__/u },
+  },
+  {
+    title: 'removePrefix = "src.__fixtures__"',
+    tests: [defaultTest],
+    pluginOptions: { removePrefix: 'src.__fixtures__' },
+  },
+])
+
+function cases(
+  testCases: Array<{
+    title: string,
+    tests: $ReadOnlyArray<{ title: string, code: string }>,
+  }>
+) {
+  const defaultOpts = {
+    title: '',
+    plugin,
+    snapshot: true,
+    babelOptions: { filename, parserOpts: { plugins: ['jsx'] } },
+    tests: [],
+  }
+  for (const testCase of testCases) {
+    testCase.tests = testCase.tests.map(t => ({ ...t, title: t.title }))
+    pluginTester({ ...defaultOpts, ...testCase })
+  }
+}


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) / 何が変更されていますか？-->
**What**: `intl.formatMessage()` support added

<!-- Why are these changes necessary? / なぜその変更をする必要がありましたか？-->
**Why**: It was not supported before despite the fact that it is a part of the official react-intl package.

<!-- How were these changes implemented? / これらの変更をどのように実装しましたか？-->
**How**: Based on existing code and based on PR for original react-intl babel plugin yahoo/babel-plugin-react-intl#165

**Checklist**: <!-- add "N/A" to the end of each line that's irrelevant to your changes to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments. -->
If I miss something, please let me know. I would be happy to fix it.