### PR TITLE
Support fixed prefix for react-intl/defineMessages

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,38 @@ const MyComponent = () => <FormattedMessage defaultMessage="goodbye {name}" />
 
 See [examples](https://github.com/akameco/babel-plugin-react-intl-auto/tree/master/examples).
 
+### Use fixed prefix instead of file path
+
+#### Before
+
+```js
+import { defineMessages } from 'react-intl'
+
+export default defineMessages({
+  hello: {
+    id: 'MainTexts.hello',
+    defaultMessage: 'hello {name}',
+  },
+  welcome: {
+    id: 'MainTexts.welcome',
+    defaultMessage: 'Welcome!',
+  },
+})
+```
+
+#### After
+
+With babel-plugin-react-intl-auto.
+
+```js
+import { defineMessages } from 'react-intl'
+
+export default defineMessages('MainTexts', {
+  hello: 'hello {name}',
+  welcome: 'Welcome!',
+})
+```
+
 ### With `extract-react-intl-messages`
 
 Example usage with [extract-react-intl-messages](https://github.com/akameco/extract-react-intl-messages).

--- a/src/__tests__/__snapshots__/fixedPrefix.test.js.snap
+++ b/src/__tests__/__snapshots__/fixedPrefix.test.js.snap
@@ -1,0 +1,101 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`default ignore empty static prefix: ignore empty static prefix 1`] = `
+
+import { defineMessages } from 'react-intl'
+
+export default defineMessages('', {
+  hello: 'hello',
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { defineMessages } from 'react-intl';
+export default defineMessages({
+  hello: {
+    "id": "src.__fixtures__.hello",
+    "defaultMessage": 'hello'
+  }
+});
+
+`;
+
+exports[`default multi export with the same prefix: multi export with the same prefix 1`] = `
+
+import { defineMessages } from 'react-intl'
+
+export const extra = defineMessages('customStaticPrefix', {
+  hello: 'hello world extra'
+})
+
+export default defineMessages('customStaticPrefix', {
+  hello: 'hello world',
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { defineMessages } from 'react-intl';
+export const extra = defineMessages({
+  hello: {
+    "id": "customStaticPrefix.hello",
+    "defaultMessage": 'hello world extra'
+  }
+});
+export default defineMessages({
+  hello: {
+    "id": "customStaticPrefix.hello",
+    "defaultMessage": 'hello world'
+  }
+});
+
+`;
+
+exports[`default multi export: multi export 1`] = `
+
+import { defineMessages } from 'react-intl'
+
+export const extra = defineMessages('customStaticPrefix', {
+  hello: 'hello world extra'
+})
+
+export default defineMessages('anotherCustomPrefix', {
+  hello: 'hello world',
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { defineMessages } from 'react-intl';
+export const extra = defineMessages({
+  hello: {
+    "id": "customStaticPrefix.hello",
+    "defaultMessage": 'hello world extra'
+  }
+});
+export default defineMessages({
+  hello: {
+    "id": "anotherCustomPrefix.hello",
+    "defaultMessage": 'hello world'
+  }
+});
+
+`;
+
+exports[`default use static prefix instead of path to file: use static prefix instead of path to file 1`] = `
+
+import { defineMessages } from 'react-intl'
+
+export default defineMessages('customStaticPrefix', {
+  hello: 'hello',
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { defineMessages } from 'react-intl';
+export default defineMessages({
+  hello: {
+    "id": "customStaticPrefix.hello",
+    "defaultMessage": 'hello'
+  }
+});
+
+`;

--- a/src/__tests__/fixedPrefix.test.js
+++ b/src/__tests__/fixedPrefix.test.js
@@ -1,0 +1,86 @@
+// @flow
+import path from 'path'
+import pluginTester from 'babel-plugin-tester'
+import plugin from '..'
+
+const filename = path.resolve(__dirname, '..', '__fixtures__', 'messages.js')
+
+const defaultTest = {
+  title: 'use static prefix instead of path to file',
+  code: `
+import { defineMessages } from 'react-intl'
+
+export default defineMessages('customStaticPrefix', {
+  hello: 'hello',
+})
+`,
+}
+
+const emptyStaticPrefixTest = {
+  title: 'ignore empty static prefix',
+  code: `
+import { defineMessages } from 'react-intl'
+
+export default defineMessages('', {
+  hello: 'hello',
+})
+`,
+}
+
+const multiExportTest = {
+  title: 'multi export',
+  code: `
+import { defineMessages } from 'react-intl'
+
+export const extra = defineMessages('customStaticPrefix', {
+  hello: 'hello world extra'
+})
+
+export default defineMessages('anotherCustomPrefix', {
+  hello: 'hello world',
+})
+`,
+}
+
+const multiExportWithTheSamePrefixTest = {
+  title: 'multi export with the same prefix',
+  code: `
+import { defineMessages } from 'react-intl'
+
+export const extra = defineMessages('customStaticPrefix', {
+  hello: 'hello world extra'
+})
+
+export default defineMessages('customStaticPrefix', {
+  hello: 'hello world',
+})
+`,
+}
+
+const tests = [
+  defaultTest,
+  emptyStaticPrefixTest,
+  multiExportTest,
+  multiExportWithTheSamePrefixTest,
+]
+
+cases([{ title: 'default', tests }])
+
+function cases(
+  testCases: Array<{
+    title: string,
+    tests: $ReadOnlyArray<{ title: string, code: string }>,
+  }>
+) {
+  const defaultOptions = {
+    title: '',
+    plugin,
+    snapshot: true,
+    babelOptions: { filename },
+    tests: [],
+  }
+  for (const testCase of testCases) {
+    testCase.tests = testCase.tests.map(t => ({ ...t, title: t.title }))
+    pluginTester({ ...defaultOptions, ...testCase })
+  }
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
English/日本語(日本語で入力して大丈夫です。日本語の方が迅速です)
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) / 何が変更されていますか？-->
**What**:
Added support of fixed prefix instead of a file path. It is extra syntax for `defineMessage`.
```js
defineMessage('myFixedPrefix', {
  hi: 'Hello',
  ok: 'Ok'
}
```
is equal to
```js
defineMessage({
  hi: {
    id: 'myFixedPrefix.hi',
    defaultMessage: 'Hello',
  },
  ok: {
    id: 'myFixedPrefix.ok',
    defaultMessage: 'Ok',
  }
}
```

<!-- Why are these changes necessary? / なぜその変更をする必要がありましたか？-->
**Why**:
Because it is needed in some situation - when you want to use semantic prefix instead of file structure prefix.

<!-- How were these changes implemented? / これらの変更をどのように実装しましたか？-->
**How**:
I powered on my pc, made warm tea :coffee: and did it.

**Checklist**: <!-- add "N/A" to the end of each line that's irrelevant to your changes to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments. -->
I think it can be useful for a lot of people because a file structure in translating is convenient not always.