### PR TITLE
Use intl hook

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -173,7 +173,7 @@ const MyComponent = () => {
 Output:
 
 ```js
-import { injectIntl } from 'react-intl'
+import { useIntl } from 'react-intl'
 
 const MyComponent = () => {
   const intl = useIntl();

--- a/readme.md
+++ b/readme.md
@@ -154,6 +154,38 @@ const MyComponent = ({ intl }) => {
 injectIntl(MyComponent)
 ```
 
+### with useIntl
+
+Input:
+
+```js
+import { useIntl } from 'react-intl'
+
+const MyComponent = () => {
+  const intl = useIntl()
+  const label = intl.formatMessage({ defaultMessage: 'Submit button' })
+  return <button aria-label={label}>{label}</button>
+}
+```
+
+↓ 　 ↓ 　 ↓
+
+Output:
+
+```js
+import { injectIntl } from 'react-intl'
+
+const MyComponent = () => {
+  const intl = useIntl();
+  const label = intl.formatMessage({ id="App.Components.Button.label", defaultMessage: 'Submit button' })
+  return (
+    <button aria-label={label}>
+      {label}
+    </button>
+  )
+}
+```
+
 ### Options
 
 #### removePrefix

--- a/src/__tests__/__snapshots__/hook.test.js.snap
+++ b/src/__tests__/__snapshots__/hook.test.js.snap
@@ -1,0 +1,244 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`default multiple uses: multiple uses 1`] = `
+
+import { useIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "hello" });
+intl.formatMessage({ defaultMessage: "hello" });
+intl.formatMessage({ defaultMessage: "some other message" });
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { useIntl } from 'react-intl';
+intl.formatMessage({
+  defaultMessage: "hello",
+  "id": "src.__fixtures__.613153351"
+});
+intl.formatMessage({
+  defaultMessage: "hello",
+  "id": "src.__fixtures__.613153351"
+});
+intl.formatMessage({
+  defaultMessage: "some other message",
+  "id": "src.__fixtures__.831373691"
+});
+
+`;
+
+exports[`default some supported use cases: some supported use cases 1`] = `
+
+import { useIntl } from 'react-intl';
+
+const Component2 = () => {
+  const intl = useIntl();
+  const label = intl.formatMessage({ defaultMessage: "hello" });
+  return (
+    <button aria-label={intl.formatMessage({ defaultMessage: "hello" })}>
+      {intl.formatMessage({ defaultMessage: "hello" })}
+    </button>
+  );
+};
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { useIntl } from 'react-intl';
+
+const Component2 = () => {
+  const intl = useIntl();
+  const label = intl.formatMessage({
+    defaultMessage: "hello",
+    "id": "src.__fixtures__.613153351"
+  });
+  return <button aria-label={intl.formatMessage({
+    defaultMessage: "hello",
+    "id": "src.__fixtures__.613153351"
+  })}>
+      {intl.formatMessage({
+      defaultMessage: "hello",
+      "id": "src.__fixtures__.613153351"
+    })}
+    </button>;
+};
+
+`;
+
+exports[`default with FormattedMessage imported as something else: with FormattedMessage imported as something else 1`] = `
+
+import { useIntl as i18n } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "i18n" });
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { useIntl as i18n } from 'react-intl';
+intl.formatMessage({
+  defaultMessage: "i18n",
+  "id": "src.__fixtures__.94348014"
+});
+
+`;
+
+exports[`default with a value interpolated in the message: with a value interpolated in the message 1`] = `
+
+import { useIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: \`template string 2\` });
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { useIntl } from 'react-intl';
+intl.formatMessage({
+  defaultMessage: \`template string 2\`,
+  "id": "src.__fixtures__.1045198380"
+});
+
+`;
+
+exports[`default with a variable as the defaultMessage: with a variable as the defaultMessage 1`] = `
+
+import { useIntl } from 'react-intl';
+
+const message = "variable message";
+
+intl.formatMessage({ defaultMessage: message });
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { useIntl } from 'react-intl';
+const message = "variable message";
+intl.formatMessage({
+  defaultMessage: message,
+  "id": "src.__fixtures__.3082794952"
+});
+
+`;
+
+exports[`default with custom properties in formatMessage call: with custom properties in formatMessage call 1`] = `
+
+import { useIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "custom prop", other: 123 });
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { useIntl } from 'react-intl';
+intl.formatMessage({
+  defaultMessage: "custom prop",
+  "id": "src.__fixtures__.2983810267",
+  other: 123
+});
+
+`;
+
+exports[`default with useIntl hook imported: with useIntl hook imported 1`] = `
+
+import { useIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "hello" });
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { useIntl } from 'react-intl';
+intl.formatMessage({
+  defaultMessage: "hello",
+  "id": "src.__fixtures__.613153351"
+});
+
+`;
+
+exports[`filebase = true with useIntl hook imported: with useIntl hook imported 1`] = `
+
+import { useIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "hello" });
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { useIntl } from 'react-intl';
+intl.formatMessage({
+  defaultMessage: "hello",
+  "id": "src.__fixtures__.messages.613153351"
+});
+
+`;
+
+exports[`removePrefix = "src" with useIntl hook imported: with useIntl hook imported 1`] = `
+
+import { useIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "hello" });
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { useIntl } from 'react-intl';
+intl.formatMessage({
+  defaultMessage: "hello",
+  "id": "__fixtures__.613153351"
+});
+
+`;
+
+exports[`removePrefix = "src.__fixtures__" with useIntl hook imported: with useIntl hook imported 1`] = `
+
+import { useIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "hello" });
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { useIntl } from 'react-intl';
+intl.formatMessage({
+  defaultMessage: "hello",
+  "id": "613153351"
+});
+
+`;
+
+exports[`removePrefix = "src/" -- with slash with useIntl hook imported: with useIntl hook imported 1`] = `
+
+import { useIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "hello" });
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { useIntl } from 'react-intl';
+intl.formatMessage({
+  defaultMessage: "hello",
+  "id": "__fixtures__.613153351"
+});
+
+`;
+
+exports[`removePrefix = /__fixtures__/ with useIntl hook imported: with useIntl hook imported 1`] = `
+
+import { useIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "hello" });
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { useIntl } from 'react-intl';
+intl.formatMessage({
+  defaultMessage: "hello",
+  "id": "src.613153351"
+});
+
+`;
+
+exports[`removePrefix = false with useIntl hook imported: with useIntl hook imported 1`] = `
+
+import { useIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "hello" });
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { useIntl } from 'react-intl';
+intl.formatMessage({
+  defaultMessage: "hello",
+  "id": "src.__fixtures__.613153351"
+});
+
+`;

--- a/src/__tests__/hook.test.js
+++ b/src/__tests__/hook.test.js
@@ -1,0 +1,210 @@
+// @flow
+import path from 'path'
+import pluginTester from 'babel-plugin-tester'
+import plugin from '..'
+
+const filename = path.resolve(__dirname, '..', '__fixtures__', 'messages.js')
+
+const defaultTest = {
+  title: 'with useIntl hook imported',
+  code: `
+import { useIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "hello" });
+  `,
+}
+
+const multiUseTest = {
+  title: 'multiple uses',
+  code: `
+import { useIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "hello" });
+intl.formatMessage({ defaultMessage: "hello" });
+intl.formatMessage({ defaultMessage: "some other message" });
+`,
+}
+
+const withValueInMessageTest = {
+  title: 'with a value interpolated in the message',
+  code: `
+import { useIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: \`template string ${1 + 1}\` });
+`,
+}
+
+const withVariableMessageTest = {
+  title: 'with a variable as the defaultMessage',
+  code: `
+import { useIntl } from 'react-intl';
+
+const message = "variable message";
+
+intl.formatMessage({ defaultMessage: message });
+`,
+}
+
+const withCustomProperties = {
+  title: 'with custom properties in formatMessage call',
+  code: `
+import { useIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "custom prop", other: 123 });
+`,
+}
+
+const someSupportedUseCases = {
+  title: 'some supported use cases',
+  code: `
+import { useIntl } from 'react-intl';
+
+const Component2 = () => {
+  const intl = useIntl();
+  const label = intl.formatMessage({ defaultMessage: "hello" });
+  return (
+    <button aria-label={intl.formatMessage({ defaultMessage: "hello" })}>
+      {intl.formatMessage({ defaultMessage: "hello" })}
+    </button>
+  );
+};
+  `,
+}
+
+const importAsTest = {
+  title: 'with FormattedMessage imported as something else',
+  code: `
+import { useIntl as i18n } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "i18n" });
+`,
+}
+
+const throwWhenNotAnalyzableTest = {
+  title: 'throws if defaultMessage isn’t analyzable',
+  code: `
+import { useIntl } from 'react-intl';
+const getMsg = () => 'hello';
+intl.formatMessage({
+  defaultMessage: getMsg(),
+});
+`,
+  error: /\[React Intl Auto\] defaultMessage must be statically evaluate-able for extraction/u,
+  snapshot: false,
+}
+
+const notTransformIfNotImportedTest = {
+  title: 'does nothing if react-intl is not imported',
+  snapshot: false,
+  code: `
+import any from 'any-module';
+intl.formatMessage({
+  defaultMessage: "hello"
+});
+`,
+}
+
+const notTransformIfIdIsProvided = {
+  title: 'does nothing if id is already provided',
+  snapshot: false,
+  code: `
+import { useIntl } from 'react-intl';
+intl.formatMessage({
+  id: "my.custom.id",
+  defaultMessage: "hello"
+});
+`,
+}
+
+const tests = [
+  defaultTest,
+  multiUseTest,
+  withValueInMessageTest,
+  withVariableMessageTest,
+  withCustomProperties,
+  someSupportedUseCases,
+  importAsTest,
+  throwWhenNotAnalyzableTest,
+  notTransformIfNotImportedTest,
+  notTransformIfIdIsProvided,
+]
+
+cases([
+  { title: 'default', tests },
+  {
+    title: 'removePrefix = "src"',
+    tests: [defaultTest],
+    pluginOptions: { removePrefix: 'src' },
+  },
+  {
+    title: 'removePrefix = "src/" -- with slash',
+    tests: [defaultTest],
+    pluginOptions: { removePrefix: 'src/' },
+  },
+  {
+    title: 'filebase = true',
+    tests: [defaultTest],
+    pluginOptions: { filebase: true },
+  },
+  // {
+  //   title: 'includeExportName = true',
+  //   tests: [defaultTest],
+  //   pluginOptions: { includeExportName: true },
+  // },
+  // {
+  //   title: 'includeExportName = all',
+  //   tests: [defaultTest],
+  //   pluginOptions: { includeExportName: 'all' },
+  // },
+  // {
+  //   title: 'removePrefix = true, includeExportName = true',
+  //   tests: [defaultTest],
+  //   pluginOptions: { removePrefix: true, includeExportName: true },
+  // },
+  {
+    title: 'removePrefix = false',
+    tests: [defaultTest],
+    pluginOptions: { removePrefix: false },
+  },
+  // {
+  //   title: 'removePrefix = true, includeExportName = all',
+  //   tests: [defaultTest],
+  //   pluginOptions: { removePrefix: true, includeExportName: 'all' },
+  // },
+  // {
+  //   title: 'extractComments = false',
+  //   tests: [defaultTest],
+  //   pluginOptions: { extractComments: false },
+  // },
+  {
+    title: 'removePrefix = /__fixtures__/',
+    tests: [defaultTest],
+    pluginOptions: { removePrefix: /[\\/]__fixtures__/u },
+  },
+  {
+    title: 'removePrefix = "src.__fixtures__"',
+    tests: [defaultTest],
+    pluginOptions: { removePrefix: 'src.__fixtures__' },
+  },
+])
+
+function cases(
+  testCases: Array<{
+    title: string,
+    tests: $ReadOnlyArray<{ title: string, code: string }>,
+  }>
+) {
+  const defaultOpts = {
+    title: '',
+    plugin,
+    snapshot: true,
+    babelOptions: { filename, parserOpts: { plugins: ['jsx'] } },
+    tests: [],
+  }
+  // Apparently a bug in eslint
+  // eslint-disable-next-line no-unused-vars
+  for (const testCase of testCases) {
+    testCase.tests = testCase.tests.map(t => ({ ...t, title: t.title }))
+    pluginTester({ ...defaultOpts, ...testCase })
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -124,6 +124,8 @@ const replaceProperties = (
 ) => {
   const prefix = getPrefix(state, exportName)
 
+  // Apparently a bug in eslint
+  // eslint-disable-next-line no-unused-vars
   for (const prop of properties) {
     const propValue = prop.get('value')
 
@@ -310,9 +312,8 @@ function isFormatMessageCall(path, state) {
   const object = callee.get('object')
 
   return (
-    // injectIntl imported
-    // isImportedFromIntl(['injectIntl'], state) &&
-    isImportLocalName(null, ['injectIntl'], state) &&
+    // injectIntl or useIntl imported
+    isImportLocalName(null, ['injectIntl', 'useIntl'], state) &&
     callee.isMemberExpression() &&
     Boolean(path.get('arguments.0')) &&
     // intl object
@@ -348,6 +349,8 @@ function addIdToFormatMessage(path, state) {
     return
   }
 
+  // Apparently a bug in eslint
+  // eslint-disable-next-line no-unused-vars
   for (const prop of properties) {
     if (prop.get('key').node.name === 'defaultMessage') {
       // try to statically evaluate defaultMessage to generate hash


### PR DESCRIPTION
**What**: Added `useIntl` hook support.


**Why**: Because `react-intl` provides hook API, therefore this plugin should support it.


**How**: Mostly copy-paste of `injectIntl` API support tests.


**Checklist**: <!-- add "N/A" to the end of each line that's irrelevant to your changes to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments. -->
