### PR TITLE
feat: useIntl with stringLiteral

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,8 @@
   "rules": {
     "unicorn/prevent-abbreviations": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
-    "@typescript-eslint/no-explicit-any": "off"
+    "@typescript-eslint/no-explicit-any": "off",
+    "import/exports-last": "off",
+    "max-lines-per-function": "off"
   }
 }

--- a/src/__tests__/__snapshots__/hook.test.ts.snap
+++ b/src/__tests__/__snapshots__/hook.test.ts.snap
@@ -131,6 +131,94 @@ intl.formatMessage({
 
 `;
 
+exports[`default with stringLiteral arrow function: with stringLiteral arrow function 1`] = `
+
+import { useIntl } from 'react-intl';
+
+const App = () => {
+  const intl = useIntl();
+  const label = intl.formatMessage("hello");
+  return (
+    <button aria-label={intl.formatMessage("submit")}>
+      {label}
+    </button>
+  );
+};
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { useIntl } from 'react-intl';
+
+const App = () => {
+  const intl = useIntl();
+  const label = intl.formatMessage({
+    "id": "src.__fixtures__.App.hello",
+    "defaultMessage": "hello"
+  });
+  return <button aria-label={intl.formatMessage({
+    "id": "src.__fixtures__.App.submit",
+    "defaultMessage": "submit"
+  })}>
+      {label}
+    </button>;
+};
+
+`;
+
+exports[`default with stringLiteral more use case: with stringLiteral more use case 1`] = `
+
+import { useIntl } from 'react-intl';
+
+function App() {
+  const intl = useIntl();
+  const label = intl.formatMessage("hello");
+  return (
+    <button aria-label={intl.formatMessage("submit")}>
+      {label}
+    </button>
+  );
+};
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { useIntl } from 'react-intl';
+
+function App() {
+  const intl = useIntl();
+  const label = intl.formatMessage({
+    "id": "src.__fixtures__.App.hello",
+    "defaultMessage": "hello"
+  });
+  return <button aria-label={intl.formatMessage({
+    "id": "src.__fixtures__.App.submit",
+    "defaultMessage": "submit"
+  })}>
+      {label}
+    </button>;
+}
+
+;
+
+`;
+
+exports[`default with stringLiteral: with stringLiteral 1`] = `
+
+import { useIntl } from 'react-intl';
+
+const intl = useIntl();
+intl.formatMessage("string literal");
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { useIntl } from 'react-intl';
+const intl = useIntl();
+intl.formatMessage({
+  "id": "src.__fixtures__.string literal",
+  "defaultMessage": "string literal"
+});
+
+`;
+
 exports[`default with useIntl hook imported: with useIntl hook imported 1`] = `
 
 import { useIntl } from 'react-intl';

--- a/src/__tests__/components.test.ts
+++ b/src/__tests__/components.test.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { cases } from '../testUtils'
+import { cases } from '../utils/testUtils'
 
 const filename = path.resolve(__dirname, '..', '__fixtures__', 'messages.js')
 

--- a/src/__tests__/hook.test.ts
+++ b/src/__tests__/hook.test.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { cases } from '../testUtils'
+import { cases } from '../utils/testUtils'
 
 const filename = path.resolve(__dirname, '..', '__fixtures__', 'messages.js')
 

--- a/src/__tests__/hook.test.ts
+++ b/src/__tests__/hook.test.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { cases } from '../utils/testUtils'
+import { cases, Test } from '../utils/testUtils'
 
 const filename = path.resolve(__dirname, '..', '__fixtures__', 'messages.js')
 
@@ -114,7 +114,7 @@ intl.formatMessage({
 `,
 }
 
-const tests = [
+const tests: Test[] = [
   defaultTest,
   multiUseTest,
   withValueInMessageTest,
@@ -125,6 +125,47 @@ const tests = [
   throwWhenNotAnalyzableTest,
   notTransformIfNotImportedTest,
   notTransformIfIdIsProvided,
+  {
+    title: 'with stringLiteral',
+    code: `
+import { useIntl } from 'react-intl';
+
+const intl = useIntl();
+intl.formatMessage("string literal");
+    `,
+  },
+  {
+    title: 'with stringLiteral more use case',
+    code: `
+import { useIntl } from 'react-intl';
+
+function App() {
+  const intl = useIntl();
+  const label = intl.formatMessage("hello");
+  return (
+    <button aria-label={intl.formatMessage("submit")}>
+      {label}
+    </button>
+  );
+};
+    `,
+  },
+  {
+    title: 'with stringLiteral arrow function',
+    code: `
+import { useIntl } from 'react-intl';
+
+const App = () => {
+  const intl = useIntl();
+  const label = intl.formatMessage("hello");
+  return (
+    <button aria-label={intl.formatMessage("submit")}>
+      {label}
+    </button>
+  );
+};
+    `,
+  },
 ]
 
 cases(filename, [

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { cases } from '../testUtils'
+import { cases } from '../utils/testUtils'
 
 const filename = path.resolve(__dirname, '..', '__fixtures__', 'messages.js')
 

--- a/src/__tests__/injection.test.ts
+++ b/src/__tests__/injection.test.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { cases } from '../testUtils'
+import { cases } from '../utils/testUtils'
 
 const filename = path.resolve(__dirname, '..', '__fixtures__', 'messages.js')
 

--- a/src/utils/testUtils.ts
+++ b/src/utils/testUtils.ts
@@ -3,14 +3,19 @@ import pluginTester from 'babel-plugin-tester'
 import { Opts } from '../types'
 import plugin from '..'
 
-export function cases(
-  filename: string,
-  testCases: {
-    title: string
-    tests: { title: string; code: string }[]
-    pluginOptions?: Opts
-  }[]
-) {
+export type Test = {
+  title: string
+  code: string
+  only?: boolean
+}
+
+export type TestCase = {
+  title: string
+  tests: Test[]
+  pluginOptions?: Opts
+}
+
+export function cases(filename: string, testCases: TestCase[]) {
   const defaultOpts = {
     title: '',
     plugin,

--- a/src/utils/testUtils.ts
+++ b/src/utils/testUtils.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import pluginTester from 'babel-plugin-tester'
-import { Opts } from './types'
-import plugin from '.'
+import { Opts } from '../types'
+import plugin from '..'
 
 export function cases(
   filename: string,


### PR DESCRIPTION


<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
English/日本語(日本語で入力して大丈夫です。日本語の方が迅速です)
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) / 何が変更されていますか？-->
**What**: Support useIntl with stringLiteral.

```tsx
import { useIntl } from 'react-intl';

function App() {
  const intl = useIntl();
  const label = intl.formatMessage("hello");
  return (
    <button aria-label={intl.formatMessage("submit")}>
      {label}
    </button>
  );
};

↓　↓　↓

import { useIntl } from 'react-intl';

const App = () => {
  const intl = useIntl();
  const label = intl.formatMessage({
    "id": "src.__fixtures__.App.hello",
    "defaultMessage": "hello"
  });
  return <button aria-label={intl.formatMessage({
    "id": "src.__fixtures__.App.submit",
    "defaultMessage": "submit"
  })}>
      {label}
    </button>;
```


<!-- Why are these changes necessary? / なぜその変更をする必要がありましたか？-->
**Why**: Easy to use


<!-- How were these changes implemented? / これらの変更をどのように実装しましたか？-->
**How**:


**Checklist**: <!-- add "N/A" to the end of each line that's irrelevant to your changes to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [x] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments. -->
