### PR TITLE
Add support for custom separator

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -165,6 +165,16 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "ericmasiello",
+      "name": "Eric Masiello",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/3525886?v=4",
+      "profile": "https://github.com/ericmasiello",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ],
   "repoType": "github",

--- a/readme.md
+++ b/readme.md
@@ -352,6 +352,32 @@ Default: `false`
 <FormattedMessage id="path.to.file.foobar" key="foobar" defaultMessage="hello" />
 ```
 
+#### separator
+
+Allows you to specify a custom separator
+
+Type: `string` <br>
+Default: `.`
+
+##### Example
+
+when `separator` is `"_"`
+
+```js
+export const test = defineMessages({
+  hello: 'hello {name}',
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+export const test = defineMessages({
+  hello: {
+    id: 'path_to_file_test_hello',
+    defaultMessage: 'hello {name}',
+  },
+})
+```
+
 ### Support variable
 
 ##### Example
@@ -459,6 +485,7 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
   <tr>
     <td align="center"><a href="https://github.com/dominik-zeglen"><img src="https://avatars3.githubusercontent.com/u/6833443?v=4" width="100px;" alt="Dominik Żegleń"/><br /><sub><b>Dominik Żegleń</b></sub></a><br /><a href="https://github.com/akameco/babel-plugin-react-intl-auto/commits?author=dominik-zeglen" title="Code">💻</a> <a href="https://github.com/akameco/babel-plugin-react-intl-auto/commits?author=dominik-zeglen" title="Tests">⚠️</a></td>
     <td align="center"><a href="https://github.com/Filson14"><img src="https://avatars1.githubusercontent.com/u/4540538?v=4" width="100px;" alt="Filip "Filson" Pasternak"/><br /><sub><b>Filip "Filson" Pasternak</b></sub></a><br /><a href="https://github.com/akameco/babel-plugin-react-intl-auto/commits?author=Filson14" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/ericmasiello"><img src="https://avatars3.githubusercontent.com/u/3525886?v=4" width="100px;" alt="Eric Masiello"/><br /><sub><b>Eric Masiello</b></sub></a><br /><a href="https://github.com/akameco/babel-plugin-react-intl-auto/commits?author=ericmasiello" title="Code">💻</a> <a href="https://github.com/akameco/babel-plugin-react-intl-auto/commits?author=ericmasiello" title="Tests">⚠️</a></td>
   </tr>
 </table>
 

--- a/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/__snapshots__/index.test.ts.snap
@@ -895,3 +895,153 @@ export default defineMessages({
 });
 
 `;
+
+exports[`separator = "" default: default 1`] = `
+
+import { defineMessages } from 'react-intl'
+
+export default defineMessages({
+  hello: 'hello',
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { defineMessages } from 'react-intl';
+export default defineMessages({
+  hello: {
+    "id": "src__fixtures__hello",
+    "defaultMessage": 'hello'
+  }
+});
+
+`;
+
+exports[`separator = "" multi export: multi export 1`] = `
+
+import { defineMessages } from 'react-intl'
+
+export const extra = defineMessages({
+  hello: 'hello world extra'
+})
+
+export default defineMessages({
+  hello: 'hello world',
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { defineMessages } from 'react-intl';
+export const extra = defineMessages({
+  hello: {
+    "id": "src__fixtures__hello",
+    "defaultMessage": 'hello world extra'
+  }
+});
+export default defineMessages({
+  hello: {
+    "id": "src__fixtures__hello",
+    "defaultMessage": 'hello world'
+  }
+});
+
+`;
+
+exports[`separator = "_" default: default 1`] = `
+
+import { defineMessages } from 'react-intl'
+
+export default defineMessages({
+  hello: 'hello',
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { defineMessages } from 'react-intl';
+export default defineMessages({
+  hello: {
+    "id": "src___fixtures___hello",
+    "defaultMessage": 'hello'
+  }
+});
+
+`;
+
+exports[`separator = "_" multi export: multi export 1`] = `
+
+import { defineMessages } from 'react-intl'
+
+export const extra = defineMessages({
+  hello: 'hello world extra'
+})
+
+export default defineMessages({
+  hello: 'hello world',
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { defineMessages } from 'react-intl';
+export const extra = defineMessages({
+  hello: {
+    "id": "src___fixtures___hello",
+    "defaultMessage": 'hello world extra'
+  }
+});
+export default defineMessages({
+  hello: {
+    "id": "src___fixtures___hello",
+    "defaultMessage": 'hello world'
+  }
+});
+
+`;
+
+exports[`separator = "foo" default: default 1`] = `
+
+import { defineMessages } from 'react-intl'
+
+export default defineMessages({
+  hello: 'hello',
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { defineMessages } from 'react-intl';
+export default defineMessages({
+  hello: {
+    "id": "srcfoo__fixtures__foohello",
+    "defaultMessage": 'hello'
+  }
+});
+
+`;
+
+exports[`separator = "foo" multi export: multi export 1`] = `
+
+import { defineMessages } from 'react-intl'
+
+export const extra = defineMessages({
+  hello: 'hello world extra'
+})
+
+export default defineMessages({
+  hello: 'hello world',
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { defineMessages } from 'react-intl';
+export const extra = defineMessages({
+  hello: {
+    "id": "srcfoo__fixtures__foohello",
+    "defaultMessage": 'hello world extra'
+  }
+});
+export default defineMessages({
+  hello: {
+    "id": "srcfoo__fixtures__foohello",
+    "defaultMessage": 'hello world'
+  }
+});
+
+`;

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -337,4 +337,29 @@ cases(filename, [
       moduleSourceName: 'gatsby-plugin-intl',
     },
   },
+
+  {
+    title: 'separator = ""',
+    tests: [defaultTest, multiExportTest],
+    pluginOptions: {
+      separator: '',
+    },
+  },
+
+  {
+    title: 'separator = "_"',
+    // tests: [defaultTest, multiExportTest],
+    tests: [defaultTest, multiExportTest],
+    pluginOptions: {
+      separator: '_',
+    },
+  },
+
+  {
+    title: 'separator = "foo"',
+    tests: [defaultTest, multiExportTest],
+    pluginOptions: {
+      separator: 'foo',
+    },
+  },
 ])

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export type Opts = {
   extractComments?: boolean
   useKey?: boolean
   moduleSourceName?: string
+  separator?: string
 }
 
 export type State = {

--- a/src/utils/getPrefix.ts
+++ b/src/utils/getPrefix.ts
@@ -2,12 +2,38 @@ import { relative, dirname, sep } from 'path'
 import { State } from '../types'
 import { dotPath } from '.'
 
+const escapeRegExp = (text: string) => {
+  return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/gu, '\\$&')
+}
+
+const dotPathReplace = (
+  fomatted: string,
+  removePrefix: string,
+  separator?: string
+) => {
+  const exp = `^${removePrefix.replace(/\//gu, '')}\\${dotPath(
+    sep,
+    separator
+  )}?`
+  let reg: RegExp
+
+  // certain separators can throw an error and need to be escaped
+  // e.g. "_"
+  try {
+    reg = new RegExp(exp, 'u')
+  } catch (error) {
+    reg = new RegExp(escapeRegExp(exp), 'u')
+  }
+
+  return dotPath(fomatted, separator).replace(reg, '')
+}
+
 export const getPrefix = (
   {
     file: {
       opts: { filename },
     },
-    opts: { removePrefix, filebase = false },
+    opts: { removePrefix, filebase = false, separator },
   }: State,
   exportName: string | null
 ) => {
@@ -18,17 +44,11 @@ export const getPrefix = (
   const fomatted = filebase ? file.replace(/\..+$/u, '') : dirname(file)
   removePrefix =
     removePrefix === undefined || removePrefix === false ? '' : removePrefix
+
   const fixed =
     removePrefix instanceof RegExp
-      ? dotPath(fomatted.replace(removePrefix, ''))
-      : dotPath(fomatted).replace(
-          new RegExp(
-            `^${removePrefix.replace(/\//gu, '')}\\${dotPath(sep)}?`,
-            'u'
-          ),
-
-          ''
-        )
+      ? dotPath(fomatted.replace(removePrefix, ''), separator)
+      : dotPathReplace(fomatted, removePrefix, separator)
 
   if (exportName === null) {
     return fixed

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -12,7 +12,8 @@ const isObjectProperties = (
 
 export const createHash = (message: string) => `${murmur.x86.hash32(message)}`
 
-export const dotPath = (str: string) => str.replace(REG, '.')
+export const dotPath = (str: string, separator: string | undefined = '.') =>
+  str.replace(REG, separator)
 
 export const objectProperty = (
   key: string,

--- a/src/visitors/addIdToDefineMessage.ts
+++ b/src/visitors/addIdToDefineMessage.ts
@@ -7,7 +7,7 @@ import { isImportLocalName } from '../utils/isImportLocalName'
 import { getPrefix } from '../utils/getPrefix'
 // import blog from 'babel-log'
 
-const getId = (path: NodePath, prefix: string) => {
+const getId = (path: NodePath, prefix: string, separator?: string) => {
   let name
 
   if (path.isStringLiteral()) {
@@ -20,7 +20,7 @@ const getId = (path: NodePath, prefix: string) => {
     throw new Error(`requires Object key or string literal`)
   }
 
-  return dotPath(join(prefix, name))
+  return dotPath(join(prefix, name), separator)
 }
 
 const getLeadingComment = (prop: NodePath) => {
@@ -37,6 +37,9 @@ const replaceProperties = (
   exportName: string | null
 ) => {
   const prefix = getPrefix(state, exportName)
+  const {
+    opts: { separator },
+  } = state
 
   for (const prop of properties) {
     const objectValuePath = prop.get('value')
@@ -60,7 +63,7 @@ const replaceProperties = (
       })
 
       if (isNotHaveId) {
-        const id = getId(objectKeyPath, prefix)
+        const id = getId(objectKeyPath, prefix, separator)
 
         messageDescriptorProperties.push(objectProperty('id', id))
       }
@@ -71,7 +74,7 @@ const replaceProperties = (
       objectValuePath.isTemplateLiteral()
     ) {
       // 'hello' or `hello ${user}`
-      const id = getId(objectKeyPath, prefix)
+      const id = getId(objectKeyPath, prefix, separator)
 
       messageDescriptorProperties.push(
         objectProperty('id', id),
@@ -80,7 +83,7 @@ const replaceProperties = (
     } else {
       const evaluated = prop.get('value').evaluate()
       if (evaluated.confident && typeof evaluated.value === 'string') {
-        const id = dotPath(join(prefix, evaluated.value))
+        const id = dotPath(join(prefix, evaluated.value), separator)
 
         messageDescriptorProperties.push(
           objectProperty('id', id),


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
English/日本語(日本語で入力して大丈夫です。日本語の方が迅速です)
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) / 何が変更されていますか？-->
**What**:

This adds support for custom "separators." By default, `babel-plugin-react-intl-auto` will join the key from a `defineMessages` and the path to that key by separating each part with a `"."`. For example:

```js
// src/components/Button.js

import { defineMessags } from '...';

const messages = defineMessages({
  greeting: 'Hello',
});
```

```js
import { defineMessags } from '...';

const messages = defineMessags({
  greeting: {
    id: 'src.components.Button.hello',
    defaultMessage: 'Hello',
  }
})
```

By defining a custom separator, you can replace the `"."` with a different value. For example, using `separator: "_"` would yield this:

```js
import { defineMessags } from '...';

const messages = defineMessags({
  greeting: {
    id: 'src_components_Button_hello',
    defaultMessage: 'Hello',
  }
})
```

<!-- Why are these changes necessary? / なぜその変更をする必要がありましたか？-->
**Why**:

I am working on a project with Gatsby where I'd like to be able to:

1. Define my strings in my components
2. Extract those strings int JSON files for each supported locale
3. Be able to query the extracted JSON files via GraphQL

The first two parts of this are already supported by the library. However, when attempting to read the JSON files contents via GraphQL, I was unsuccessful. As best I can tell, GraphQL does not support `.` in the keys and was replacing them with `_` by default. However, when the GraphQL query would query the value where the key was replaced (from `'.'` -> `'_'`) the strings would not appear.

After some experimentation, I realized that if I manually replace the `.` with a different separator the GraphQL query would respond with the data as expected.

<!-- How were these changes implemented? / これらの変更をどのように実装しましたか？-->
**How**:

Inside your babel config, you specify a `"separator"` value. If you do not specify one, internally we fall back the default `"."` value. This means this will not have any negative impact on existing users.

**Checklist**: <!-- add "N/A" to the end of each line that's irrelevant to your changes to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments. -->

I noticed that certain separator strings would throw an exception when running through a particular code path that involved a series of `RegExp` replacements. The best solution I could come to was ty wrap the `RegExp` in a `try/catch` and then if the expression failed, I would then escape the strings and try again. Originally I tried to always escape the strings but that caused existing tests to fail. That is why I went with the `try/catch` approach. I am open to feedback on a better way to implement this.
