### PR TITLE
feat: useKey support to intl.formatMessage

### DIFF
--- a/src/__tests__/__snapshots__/hook.test.ts.snap
+++ b/src/__tests__/__snapshots__/hook.test.ts.snap
@@ -188,6 +188,25 @@ intl.formatMessage({
 
 `;
 
+exports[`default withKeyFlag: withKeyFlag 1`] = `
+
+import { useIntl } from 'react-intl';
+intl.formatMessage({
+  key: 'foobar',
+  defaultMessage: 'hello'
+});
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { useIntl } from 'react-intl';
+intl.formatMessage({
+  key: 'foobar',
+  defaultMessage: 'hello',
+  "id": "src.__fixtures__.613153351"
+});
+
+`;
+
 exports[`filebase = true with useIntl hook imported: with useIntl hook imported 1`] = `
 
 import { useIntl } from 'react-intl';
@@ -280,6 +299,41 @@ import { useIntl } from 'react-intl';
 intl.formatMessage({
   defaultMessage: "hello",
   "id": "src.__fixtures__.613153351"
+});
+
+`;
+
+exports[`useKey = true with useIntl hook imported: with useIntl hook imported 1`] = `
+
+import { useIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "hello" });
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { useIntl } from 'react-intl';
+intl.formatMessage({
+  defaultMessage: "hello",
+  "id": "src.__fixtures__.613153351"
+});
+
+`;
+
+exports[`useKey = true withKeyFlag: withKeyFlag 1`] = `
+
+import { useIntl } from 'react-intl';
+intl.formatMessage({
+  key: 'foobar',
+  defaultMessage: 'hello'
+});
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { useIntl } from 'react-intl';
+intl.formatMessage({
+  key: 'foobar',
+  defaultMessage: 'hello',
+  "id": "src.__fixtures__.foobar"
 });
 
 `;

--- a/src/__tests__/hook.test.ts
+++ b/src/__tests__/hook.test.ts
@@ -136,6 +136,17 @@ export default injectIntl(App)
   `,
 }
 
+const withKeyFlag = {
+  title: 'withKeyFlag',
+  code: `
+import { useIntl } from 'react-intl';
+intl.formatMessage({
+  key: 'foobar',
+  defaultMessage: 'hello'
+});
+  `,
+}
+
 const tests = [
   defaultTest,
   multiUseTest,
@@ -149,6 +160,7 @@ const tests = [
   notTransformIfNotImportedTest,
   notTransformIfIdIsProvided,
   injectIntlWithProps,
+  withKeyFlag,
 ]
 
 cases(filename, [
@@ -212,5 +224,10 @@ cases(filename, [
     title: 'removePrefix = "src.__fixtures__"',
     tests: [defaultTest],
     pluginOptions: { removePrefix: 'src.__fixtures__' },
+  },
+  {
+    title: 'useKey = true',
+    tests: [defaultTest, withKeyFlag],
+    pluginOptions: { useKey: true },
   },
 ])

--- a/src/visitors/addIdToFormatMessage.ts
+++ b/src/visitors/addIdToFormatMessage.ts
@@ -49,6 +49,31 @@ function isFormatMessageCall(path: NodePath<t.CallExpression>, state: State) {
   return Boolean(path.get('arguments.0')) && isIntl && isFormatMessage
 }
 
+function findProperty(
+  properties: NodePath<t.ObjectProperty>[],
+  name: string
+): NodePath<t.ObjectProperty> | undefined {
+  return properties.find((arg) => {
+    const keyPath = arg.get('key')
+    return !Array.isArray(keyPath) && keyPath.node.name === name
+  })
+}
+
+function extractKeyValue(
+  properties: NodePath<t.ObjectProperty>[]
+): string | null {
+  const prop = findProperty(properties, 'key')
+  if (prop) {
+    const keyPath = prop.get('key')
+    if (!Array.isArray(keyPath) && keyPath.node.name === 'key') {
+      const valuePath = prop.get('value')
+      const value = valuePath.evaluate().value
+      return value
+    }
+  }
+  return null
+}
+
 // add automatic ID to intl.formatMessage calls
 export function addIdToFormatMessage(
   path: NodePath<t.CallExpression>,
@@ -71,31 +96,30 @@ export function addIdToFormatMessage(
   }
 
   // if "id" property is already added by a developer or by this script just skip this node
-  if (
-    properties.find((arg) => {
-      const keyPath = arg.get('key')
-      return !Array.isArray(keyPath) && keyPath.node.name === 'id'
-    })
-  ) {
+  if (findProperty(properties, 'id')) {
     return
   }
 
-  for (const prop of properties) {
-    const keyPath = prop.get('key')
-    if (!Array.isArray(keyPath) && keyPath.node.name === 'defaultMessage') {
-      // try to statically evaluate defaultMessage to generate hash
-      const evaluated = prop.get('value').evaluate()
+  const keyValue = extractKeyValue(properties)
 
-      if (!evaluated.confident || typeof evaluated.value !== 'string') {
-        throw prop
-          .get('value')
-          .buildCodeFrameError(
-            '[React Intl Auto] defaultMessage must be statically evaluate-able for extraction.'
-          )
-      }
-      prop.insertAfter(
-        objectProperty('id', getPrefix(state, createHash(evaluated.value)))
-      )
+  const defaultMessageProp = findProperty(properties, 'defaultMessage')
+  if (defaultMessageProp) {
+    // try to statically evaluate defaultMessage to generate hash
+    const evaluated = defaultMessageProp.get('value').evaluate()
+
+    if (!evaluated.confident || typeof evaluated.value !== 'string') {
+      throw defaultMessageProp
+        .get('value')
+        .buildCodeFrameError(
+          '[React Intl Auto] defaultMessage must be statically evaluate-able for extraction.'
+        )
     }
+
+    const id = getPrefix(
+      state,
+      state.opts.useKey && keyValue ? keyValue : createHash(evaluated.value)
+    )
+
+    defaultMessageProp.insertAfter(objectProperty('id', id))
   }
 }


### PR DESCRIPTION

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
English/日本語(日本語で入力して大丈夫です。日本語の方が迅速です)
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) / 何が変更されていますか？-->
**What**: Fix #82

```js
import { useIntl } from 'react-intl';
intl.formatMessage({
  key: 'foobar',
  defaultMessage: 'hello'
});

      ↓ ↓ ↓ ↓ ↓ ↓

import { useIntl } from 'react-intl';
intl.formatMessage({
  key: 'foobar',
  defaultMessage: 'hello',
  "id": "src.App.foobar"
});
```

<!-- Why are these changes necessary? / なぜその変更をする必要がありましたか？-->
**Why**:


<!-- How were these changes implemented? / これらの変更をどのように実装しましたか？-->
**How**: 


**Checklist**: <!-- add "N/A" to the end of each line that's irrelevant to your changes to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments. -->
