### PR TITLE
feat: support useKey in type definition

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -8,4 +8,8 @@ declare module 'react-intl' {
   export function defineMessages<T extends ExtractableMessage>(
     messages: T
   ): { [K in keyof T]: MessageDescriptor }
+
+  export interface MessageDescriptor {
+    key?: string
+  }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
English/日本語(日本語で入力して大丈夫です。日本語の方が迅速です)
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) / 何が変更されていますか？-->
**What**:
* Resolves #127
* `formatMessage()` への `key` プロパティーのサポートを追加 

<!-- Why are these changes necessary? / なぜその変更をする必要がありましたか？-->
**Why**:
* TypeScript の型定義が一致しない機能のため

<!-- How were these changes implemented? / これらの変更をどのように実装しましたか？-->
**How**:
* `MessageDescriptor` との差分を追記<br><img src="https://user-images.githubusercontent.com/6535425/82813134-6c437300-9ecf-11ea-95e8-a84769893ce5.png" width="229">

**Checklist**: <!-- add "N/A" to the end of each line that's irrelevant to your changes to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments. -->
