### PR TITLE
Implemented removeDefaultMessage option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -259,6 +259,45 @@ export default defineMessages({
 });
 ```
 
+#### removeDefaultMessage
+
+Removes `defaultMessage` property from generated message descriptor.
+
+Type: `boolean` <br>
+Default: `false`
+
+If `removeDefaultMessage` is `true`, then `defaultMessage` field will be removed
+even from definitions with its own `id`.
+
+##### Example
+
+```js
+export const test = defineMessages({
+  key: 'value',
+  preserveId: {
+    id: 'this is id',
+    defaultMessage: 'id',
+  },
+  onlyDefaultMessage: {
+    defaultMessage: 'world',
+  },
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+export const test = defineMessages({
+  key: {
+    id: 'path.to.file.test.value'
+  },
+  preserveId: {
+    id: 'this is id'
+  },
+  onlyDefaultMessage: {
+    id: "path.to.file.test.onlyDefaultMessage"
+  },
+})
+```
+
 #### filebase
 
 Type: `boolean` <br>

--- a/src/__tests__/__snapshots__/components.test.ts.snap
+++ b/src/__tests__/__snapshots__/components.test.ts.snap
@@ -167,6 +167,19 @@ import { FormattedMessage } from 'react-intl';
 
 `;
 
+exports[`removeDefaultMessage = true default: default 1`] = `
+
+import { FormattedMessage } from 'react-intl';
+
+<FormattedMessage defaultMessage="hello" />;
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { FormattedMessage } from 'react-intl';
+<FormattedMessage id="src.__fixtures__.613153351" />;
+
+`;
+
 exports[`removePrefix = "src" default: default 1`] = `
 
 import { FormattedMessage } from 'react-intl';

--- a/src/__tests__/__snapshots__/hook.test.ts.snap
+++ b/src/__tests__/__snapshots__/hook.test.ts.snap
@@ -223,6 +223,21 @@ intl.formatMessage({
 
 `;
 
+exports[`removeDefaultMessage = true with useIntl hook imported: with useIntl hook imported 1`] = `
+
+import { useIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "hello" });
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { useIntl } from 'react-intl';
+intl.formatMessage({
+  "id": "src.__fixtures__.613153351"
+});
+
+`;
+
 exports[`removePrefix = "src" with useIntl hook imported: with useIntl hook imported 1`] = `
 
 import { useIntl } from 'react-intl';

--- a/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/__snapshots__/index.test.ts.snap
@@ -716,6 +716,80 @@ export default defineMessages({
 
 `;
 
+exports[`removeDefaultMessage = true Object: Object 1`] = `
+
+import { defineMessages } from 'react-intl'
+
+defineMessages({
+  new: {
+    id: 'this is id',
+    defaultMessage: 'id',
+  },
+  world: {
+    defaultMessage: 'world',
+  },
+  headerTitle: {
+    defaultMessage: 'Welcome to dashboard {name}!',
+    description: 'Message to greet the user.',
+  },
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { defineMessages } from 'react-intl';
+defineMessages({
+  new: {
+    id: 'this is id'
+  },
+  world: {
+    "id": "src.__fixtures__.world"
+  },
+  headerTitle: {
+    "id": "src.__fixtures__.headerTitle",
+    description: 'Message to greet the user.'
+  }
+});
+
+`;
+
+exports[`removeDefaultMessage = true default: default 1`] = `
+
+import { defineMessages } from 'react-intl'
+
+export default defineMessages({
+  hello: 'hello',
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { defineMessages } from 'react-intl';
+export default defineMessages({
+  hello: {
+    "id": "src.__fixtures__.hello"
+  }
+});
+
+`;
+
+exports[`removeDefaultMessage = true eval string: eval string 1`] = `
+
+import { defineMessages } from 'react-intl'
+
+export default defineMessages({
+  hello: 'hello' + 'world',
+})
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { defineMessages } from 'react-intl';
+export default defineMessages({
+  hello: {
+    "id": "src.__fixtures__.helloworld"
+  }
+});
+
+`;
+
 exports[`removePrefix = "src" default: default 1`] = `
 
 import { defineMessages } from 'react-intl'

--- a/src/__tests__/__snapshots__/injection.test.ts.snap
+++ b/src/__tests__/__snapshots__/injection.test.ts.snap
@@ -181,6 +181,21 @@ intl.formatMessage({
 
 `;
 
+exports[`removeDefaultMessage = true with Injection API HOC imported: with Injection API HOC imported 1`] = `
+
+import { injectIntl } from 'react-intl';
+
+intl.formatMessage({ defaultMessage: "hello" });
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { injectIntl } from 'react-intl';
+intl.formatMessage({
+  "id": "src.__fixtures__.613153351"
+});
+
+`;
+
 exports[`removePrefix = "src" with Injection API HOC imported: with Injection API HOC imported 1`] = `
 
 import { injectIntl } from 'react-intl';

--- a/src/__tests__/components.test.ts
+++ b/src/__tests__/components.test.ts
@@ -202,4 +202,10 @@ cases(filename, [
     tests: [defaultTest],
     pluginOptions: { removePrefix: 'src.__fixtures__' },
   },
+
+  {
+    title: 'removeDefaultMessage = true',
+    tests: [defaultTest],
+    pluginOptions: { removeDefaultMessage: true },
+  },
 ])

--- a/src/__tests__/hook.test.ts
+++ b/src/__tests__/hook.test.ts
@@ -230,4 +230,9 @@ cases(filename, [
     tests: [defaultTest, withKeyFlag],
     pluginOptions: { useKey: true },
   },
+  {
+    title: 'removeDefaultMessage = true',
+    tests: [defaultTest],
+    pluginOptions: { removeDefaultMessage: true },
+  },
 ])

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -14,6 +14,27 @@ export default defineMessages({
 `,
 }
 
+const objectTest = {
+  title: 'Object',
+  code: `
+import { defineMessages } from 'react-intl'
+
+defineMessages({
+  new: {
+    id: 'this is id',
+    defaultMessage: 'id',
+  },
+  world: {
+    defaultMessage: 'world',
+  },
+  headerTitle: {
+    defaultMessage: 'Welcome to dashboard {name}!',
+    description: 'Message to greet the user.',
+  },
+})
+`,
+}
+
 const multiExportTest = {
   title: 'multi export',
   code: `
@@ -64,6 +85,17 @@ export default defineMessages({
 `,
 }
 
+const evalStringTest = {
+  title: 'eval string',
+  code: `
+import { defineMessages } from 'react-intl'
+
+export default defineMessages({
+  hello: 'hello' + 'world',
+})
+`,
+}
+
 const tests = [
   defaultTest,
   {
@@ -88,27 +120,7 @@ defineMessages({
       `,
   },
 
-  {
-    title: 'Object',
-    code: `
-import { defineMessages } from 'react-intl'
-
-defineMessages({
-  new: {
-    id: 'this is id',
-    defaultMessage: 'id',
-  },
-  world: {
-    defaultMessage: 'world',
-  },
-  headerTitle: {
-    defaultMessage: 'Welcome to dashboard {name}!',
-    description: 'Message to greet the user.',
-  },
-})
-      `,
-  },
-
+  objectTest,
   {
     title: 'import as',
     code: `
@@ -225,16 +237,7 @@ export default defineMessages({
 
   leadingCommentTest,
   leadingCommentWithDescriptionTest,
-  {
-    title: 'eval string',
-    code: `
-import { defineMessages } from 'react-intl'
-
-export default defineMessages({
-  hello: 'hello' + 'world',
-})
-    `,
-  },
+  evalStringTest,
 ]
 
 const moduleSourceNameTest = {
@@ -376,6 +379,14 @@ cases(filename, [
     tests: [defaultTest, multiExportTest],
     pluginOptions: {
       relativeTo: '',
+    },
+  },
+
+  {
+    title: 'removeDefaultMessage = true',
+    tests: [defaultTest, objectTest, evalStringTest],
+    pluginOptions: {
+      removeDefaultMessage: true,
     },
   },
 ])

--- a/src/__tests__/injection.test.ts
+++ b/src/__tests__/injection.test.ts
@@ -200,4 +200,10 @@ cases(filename, [
     tests: [defaultTest],
     pluginOptions: { removePrefix: 'src.__fixtures__' },
   },
+
+  {
+    title: 'removeDefaultMessage = true',
+    tests: [defaultTest],
+    pluginOptions: { removeDefaultMessage: true },
+  },
 ])

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export type Opts = {
   moduleSourceName?: string
   separator?: string
   relativeTo?: string
+  removeDefaultMessage?: boolean
 }
 
 export type State = {

--- a/src/visitors/addIdToFormatMessage.ts
+++ b/src/visitors/addIdToFormatMessage.ts
@@ -75,6 +75,7 @@ function extractKeyValue(
 }
 
 // add automatic ID to intl.formatMessage calls
+// eslint-disable-next-line max-lines-per-function
 export function addIdToFormatMessage(
   path: NodePath<t.CallExpression>,
   state: State
@@ -121,5 +122,10 @@ export function addIdToFormatMessage(
     )
 
     defaultMessageProp.insertAfter(objectProperty('id', id))
+
+    // Remove defaultMessage prop if configured
+    if (state.opts.removeDefaultMessage) {
+      defaultMessageProp.remove()
+    }
   }
 }

--- a/src/visitors/jsx.ts
+++ b/src/visitors/jsx.ts
@@ -139,5 +139,10 @@ export const visitJSXElement = (path: NodePath, state: State) => {
     if (!id && defaultMessage) {
       generateId(defaultMessage, state, state.opts.useKey ? key : undefined)
     }
+
+    // Remove defaultMessage prop if configured
+    if (defaultMessage && state.opts.removeDefaultMessage) {
+      defaultMessage.remove()
+    }
   }
 }


### PR DESCRIPTION
**What**: I have implemented the `removeDefaultMessage` option.

**Why**: because otherwise my code contains duplicated source language strings: one from `defaultMessage` and one from extracted messages bundle. In production build, I want to get rid of the `defaultMessage`s and use only prebuilt bundles.

**How**: by writing code 🙃

**Checklist**:
* [x] Documentation
* [x] Tests
* [x] Ready to be merged